### PR TITLE
RitvikRC's rounding fix

### DIFF
--- a/copyTime.lua
+++ b/copyTime.lua
@@ -61,7 +61,7 @@ local function copyTime()
     local hours, minutes = divmod(minutes, 60)
     local seconds = math.floor(remainder)
     local milliseconds = math.floor((remainder - seconds) * 1000)
-    local time = string.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds)
+    local time = string.format("%02d:%02d:%02d.%03d", math.floor(hours), math.floor(minutes), seconds, milliseconds)
     if set_clipboard(time) then
         mp.osd_message(string.format("Copied to Clipboard: %s", time))
     else


### PR DESCRIPTION
The problem with previous code was that the hours and minutes are passed in as float to string.format. string.format with "%02d" on float values rounds the values up or down to the nearest integer instead of rounding them down to the closest integer.

The result of the previous code was that if the seconds value was greater than 30, the minutes value would be incorrectly incremented by 1. Similarly, if the minute value was greater than 30, the hour value would be incorrectly incremented by 1.